### PR TITLE
Publish Helm repo (using Helm Chart Releaser GitHub Action)

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -1,0 +1,23 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "scala-steward/**"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@master
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -1,0 +1,31 @@
+name: Lint and Test Charts
+
+on: pull_request
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Fetch history
+        run: git fetch --prune --unshallow
+
+      - name: Run chart-testing (lint)
+        id: lint
+        uses: helm/chart-testing-action@v1.0.0-rc.1
+        with:
+          command: lint
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.0.0-rc.1
+        # Only build a kind cluster if there are chart changes to test.
+        if: steps.lint.outputs.changed == 'true'
+        with:
+          version: v0.8.0
+
+      - name: Run chart-testing (install)
+        uses: helm/chart-testing-action@v1.0.0-rc.1
+        with:
+          command: install

--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -8,9 +8,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
-      - name: Fetch history
-        run: git fetch --prune --unshallow
+        run: |
+           git fetch --prune --unshallow
 
       - name: Run chart-testing (lint)
         id: lint


### PR DESCRIPTION
This adds two GitHub Action workflows:

1. [`chart-testing-action`](https://github.com/helm/chart-testing-action) on pull requests
2. [`chart-releaser-action`](https://github.com/helm/chart-releaser-action) on push to master

If you'd like, you could also add this chart to the Helm Hub ([here's how](https://github.com/helm/hub/blob/master/Repositories.md) and [here's another example](https://github.com/helm/hub/pull/336/files)).